### PR TITLE
update blob access example notebook

### DIFF
--- a/access data bucket.ipynb
+++ b/access data bucket.ipynb
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [
     {
@@ -38,7 +38,6 @@
     "import os\n",
     "\n",
     "bucketName = 'mpr-research-data-uploads'\n",
-    "blobName = 'comments_all_W19.tsv'\n",
     "dataFileName = os.path.join('..', 'data', blobName)\n",
     "\n",
     "client = storage.Client() # uses current project by default\n",
@@ -56,25 +55,63 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Bucket name: mpr-research-data-uploads\n",
-      "Bucket location: US\n",
-      "Bucket storage class: STANDARD\n"
+      "Bucket name: \"mpr-research-data-uploads\"\n",
+      "Bucket location: \"US\"\n",
+      "Bucket storage class: \"STANDARD\"\n"
      ]
     }
    ],
    "source": [
     "bucket = client.get_bucket(bucketName)\n",
     "\n",
-    "print(f'Bucket name: {bucket.name}')\n",
-    "print(f'Bucket location: {bucket.location}')\n",
-    "print(f'Bucket storage class: {bucket.storage_class}')"
+    "print(f'Bucket name: \"{bucket.name}\"')\n",
+    "print(f'Bucket location: \"{bucket.location}\"')\n",
+    "print(f'Bucket storage class: \"{bucket.storage_class}\"')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## list blobs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Blobs in \"mpr-research-data-uploads\":\n",
+      "\t495677 - Math 216 WN 2022.tsv\n",
+      "\t496007 - CLIMATE 102 001 WN 2022.tsv\n",
+      "\t496915 - MOVESCI 110 WN 2022.tsv\n",
+      "\t498928 - CHEM 216 100 WN 2022.tsv\n",
+      "\t506914 - MATSCIE 250 100 WN 2022.tsv\n",
+      "\t508768 - ECON 101 300 WN 2022.tsv\n",
+      "\t516081 - STATS 250 ROMERO WN 22.tsv\n"
+     ]
+    }
+   ],
+   "source": [
+    "# store GCP blob list as a Python list\n",
+    "blobs = [blob for blob in bucket.list_blobs()]\n",
+    "\n",
+    "print(f'Blobs in \"{bucket.name}\":')\n",
+    "for item in blobs:\n",
+    "    print('\\t' + item.name)"
    ]
   },
   {
@@ -86,39 +123,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Name: mpr-research-data-uploads/comments_all_W19.tsv/1651756615245369\n",
-      "Size: 86395767 bytes\n",
-      "Content type: text/tab-separated-values\n",
-      "Public URL: https://storage.googleapis.com/mpr-research-data-uploads/comments_all_W19.tsv\n"
+      "Name: \"mpr-research-data-uploads/495677 - Math 216 WN 2022.tsv/1653279017167477\"\n",
+      "Size: (5536306) bytes\n",
+      "Content type: \"text/tsv\"\n",
+      "Public URL: (https://storage.googleapis.com/mpr-research-data-uploads/495677%20-%20Math%20216%20WN%202022.tsv)\n"
      ]
     }
    ],
    "source": [
-    "blob = bucket.get_blob(blobName)\n",
+    "# examine the first blob\n",
+    "blob = blobs[0]\n",
     "\n",
-    "print(f'Name: {blob.id}')\n",
-    "print(f'Size: {blob.size} bytes')\n",
-    "print(f'Content type: {blob.content_type}')\n",
-    "print(f'Public URL: {blob.public_url}')"
+    "print(f'Name: \"{blob.id}\"')\n",
+    "print(f'Size: ({blob.size}) bytes')\n",
+    "print(f'Content type: \"{blob.content_type}\"')\n",
+    "print(f'Public URL: ({blob.public_url})')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## download blob to kernel directory"
+    "## download blob to kernel directory\n",
+    "This is an example of doing _something_ with a blob.  They may not _need_ to be downloaded to work with them."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 55,
    "metadata": {
     "tags": []
    },
@@ -127,8 +166,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Downloading to \"../data/comments_all_W19.tsv\"…\n",
-      "Downloaded blob \"comments_all_W19.tsv\" to \"../data/comments_all_W19.tsv\".\n"
+      "Downloading to \"../data/495677 - Math 216 WN 2022.tsv\"…\n",
+      "Downloaded blob \"495677 - Math 216 WN 2022.tsv\" to \"../data/495677 - Math 216 WN 2022.tsv\".\n"
      ]
     }
    ],
@@ -162,7 +201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [
     {
@@ -171,6 +210,7 @@
      "text": [
       "Buckets in mwrite-a835:\n",
       "\tmpr-research-data-uploads\n",
+      "\tmpr-research-data-uploads-lsloan_test\n",
       "\tmwrite-data-bucket-1\n"
      ]
     }
@@ -180,44 +220,6 @@
     "\n",
     "print(f'Buckets in {client.project}:')\n",
     "for item in buckets:\n",
-    "    print('\\t' + item.name)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "### list blobs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Blobs in mpr-research-data-uploads:\n",
-      "\t495677 - Math 216 WN 2022.tsv\n",
-      "\t496007 - CLIMATE 102 001 WN 2022.tsv\n",
-      "\t496915 - MOVESCI 110 WN 2022.tsv\n",
-      "\t498928 - CHEM 216 100 WN 2022.tsv\n",
-      "\t506914 - MATSCIE 250 100 WN 2022.tsv\n",
-      "\t508768 - ECON 101 300 WN 2022.tsv\n",
-      "\t516081 - STATS 250 ROMERO WN 22.tsv\n",
-      "\tcomments_all_W19.tsv\n"
-     ]
-    }
-   ],
-   "source": [
-    "blobs = bucket.list_blobs()\n",
-    "\n",
-    "print(f'Blobs in {bucket.name}:')\n",
-    "for item in blobs:\n",
     "    print('\\t' + item.name)"
    ]
   },


### PR DESCRIPTION
Small changes in the code to work with multiple blobs in the bucket.  Remove the hard-coded blob name.  Get the list of blobs and use the first one as the example.

This PR is to make up for the unsigned commit I made from JupyterLab directly to the upstream repo.