### PR TITLE
Remove Mandatory GCP Bucket Validation (iss. #23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,31 +7,31 @@
    > "SCW | M-Write" shared Google Drive under  
    > "MPR Technical" > "MPR Config Secrets" > "Prod".
 
-2. Get GCP credentials for accessing bucket:
-   Use Service Account 'dbToGCPHelper' for accessing and pushing to GCP.
+2. Get GCP credentials for accessing bucket:  
+   Use Service Account 'dbToGCPHelper' for accessing and pushing to GCP.  
    > Using GCP Web UI, go to "IAM & Admin" > "Service Accounts" (https://console.cloud.google.com/iam-admin/serviceaccounts)  
    > Use the service account named "dbTOGCPHelper"  
    > Under "Actions", generate a new key-pair as a JSON file.  
    > Note: If making a new Service Account, please make sure the Service Account has appropriate permissions to be able to access and modify the GCP bucket.
 
 3. Use the `.env.sample` in the config folder to create an `.env` file in the root of the directory. 
-   > Specify the settings for DB key using values from the `database-research_ro.json` file.
-   > Specify the settings for GCP service account key using values from the downloaded GCP key file.
-Note: You need to have these keys, there are no default values.
 
-4. Adjust variables in the `.env` file before running if not applying defaults:
-   NOTE: Using Buckets are no longer the default. Use BigQuery tables instead to store data.
-   > Specify the GCP Bucket info here. Defaults to: mpr-research-data-uploads.
-      `GCLOUD_BUCKET`
-   > Specify the BigQuery table to upload data here.
-      Defaults to: mwrite-a835.mpr_research_uploaded_dataset.course-upload-data
-      `BQ_TABLE`
-   > Specify the BigQuery table to upload timestamp and syncing info here.
-   Defaults to: mwrite-a835.mpr_research_uploaded_dataset.course-upload-timestamp
-      `BQ_TIMESTAMP_TABLE`
-   > Specify the number of months backwards to search courses. Defaults to 4:
-      `NUMBER_OF_MONTHS` 
+   > Specify the settings for DB key using values from the `database-research_ro.json` file.  
+   > Specify the settings for GCP service account key using values from the downloaded GCP key file.     
+Note: You need to have these keys, there are no default values.  
 
+4. Adjust variables in the `.env` file before running if not applying defaults:  
+   NOTE: Using Buckets are no longer the default. Use BigQuery tables instead to store data.  
+   > Specify the GCP Bucket info here. Defaults to: mpr-research-data-uploads.  
+      `GCLOUD_BUCKET`  
+   > Specify the BigQuery table to upload data here.  
+      Defaults to: mwrite-a835.mpr_research_uploaded_dataset.course-upload-data  
+      `BQ_TABLE`  
+   > Specify the BigQuery table to upload timestamp and syncing info here.  
+   Defaults to: mwrite-a835.mpr_research_uploaded_dataset.course-upload-timestamp  
+      `BQ_TIMESTAMP_TABLE`  
+   > Specify the number of months backwards to search courses. Defaults to 4:  
+      `NUMBER_OF_MONTHS`  
 5. Use `docker-compose up --build` to run the application  
    1. When running in local development environment, be sure to
       activate VPN so the application can reach the MPR DB.  The

--- a/README.md
+++ b/README.md
@@ -20,8 +20,15 @@
 Note: You need to have these keys, there are no default values.
 
 4. Adjust variables in the `.env` file before running if not applying defaults:
+   NOTE: Using Buckets are no longer the default. Use BigQuery tables instead to store data.
    > Specify the GCP Bucket info here. Defaults to: mpr-research-data-uploads.
       `GCLOUD_BUCKET`
+   > Specify the BigQuery table to upload data here.
+      Defaults to: mwrite-a835.mpr_research_uploaded_dataset.course-upload-data
+      `BQ_TABLE`
+   > Specify the BigQuery table to upload timestamp and syncing info here.
+   Defaults to: mwrite-a835.mpr_research_uploaded_dataset.course-upload-timestamp
+      `BQ_TIMESTAMP_TABLE`
    > Specify the number of months backwards to search courses. Defaults to 4:
       `NUMBER_OF_MONTHS` 
 

--- a/config/.env.sample
+++ b/config/.env.sample
@@ -1,4 +1,5 @@
 # Specify the GCP Bucket info here. Defaults to: mpr-research-data-uploads.
+# Note that this bucket might not exist anymore and needs to be created if that is the case.
 GCLOUD_BUCKET='mpr-research-data-uploads'
 
 # Toggle for uploading to bucket, data is always pushed and synced to BigQuery.

--- a/mpr-research-data.py
+++ b/mpr-research-data.py
@@ -49,7 +49,7 @@ def makeGCPBucketConnection(gcpParams, targetBucketName):
             logging.info(
                 f'Bucket {targetBucketName} found in {client.project}.')
 
-        logging.info('GCP connection established and validated.')
+        logging.info('GCP Bucket connection established and validated.')
         return bucket
 
     except GAuthExceptions.RefreshError as e:
@@ -80,7 +80,7 @@ def makeGCPBigQueryConnection(gcpParams, bqTableID, bqTimestampTableID):
                     f'Table {tableID} in {client.project} not found.')
                 sys.exit('Exiting due to invalid table name.')
 
-        logging.info('GCP connection established and validated.')
+        logging.info('GCP BigQuery connection established and validated.')
         return client
 
     except GAuthExceptions.RefreshError as e:
@@ -377,8 +377,6 @@ def main():
     # ESTABLISH CONNECTIONS
     # --------------------------------------------------------------------------
     sqlEngine = makeDBConnection(config.dbParams)
-    gcpBucket = makeGCPBucketConnection(
-        config.gcpParams, config.targetBucketName)
     bqClient = makeGCPBigQueryConnection(
         config.gcpParams, config.bqTableID, config.bqTimestampTableID)
 
@@ -400,6 +398,9 @@ def main():
     # --------------------------------------------------------------------------
 
     if config.pushToBucket == 'True':
+        gcpBucket = makeGCPBucketConnection(
+            config.gcpParams, config.targetBucketName)
+
         allSaved = sliceAndPushToGCPBucket(courseQueryDF, retrieveQueryDF,
                                            gcpBucket)
         # This is because even if one course fails to save or upload
@@ -409,7 +410,7 @@ def main():
 
         if not allSaved:
             logging.warning(
-                'Not all course data could be saved to GCP correctly.')
+                'Not all course data could be saved to GCP Bucket correctly.')
 
     # SEND TO GCP BIGQUERY TABLE
     # --------------------------------------------------------------------------


### PR DESCRIPTION
This PR should fix the mandatory check that the code was doing for Bucket even if it is not being used. It should now only check for a bucket when it is configured to save to the bucket as well. The default is BigQuery.